### PR TITLE
Questao4

### DIFF
--- a/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/Company.java
+++ b/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/Company.java
@@ -26,15 +26,11 @@ public class Company {
 		int id = wrestler.getId();
 
 		for (SingleMatch match : singleMatches) {
-			if (match.getIdWinner() == id) {
-				points += 2;
-			}
+			points += match.calculatePoints(id);
 		}
 
 		for (TagMatch match : tagMatches) {
-			if (match.getIdWinnerTeamFirstMember() == id || match.getIdLoserTeamSecondMember() == id) {
-				points += 1;
-			}
+			points += match.calculatePoints(id);
 		}
 
 		return points;

--- a/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/Company.java
+++ b/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/Company.java
@@ -4,20 +4,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Company {
-	private List<SingleMatch> singleMatches;
-	private List<TagMatch> tagMatches;
+	private List<Match> matches;
 
 	public Company() {
-		this.singleMatches = new ArrayList<>();
-		this.tagMatches = new ArrayList<>();
+		this.matches = new ArrayList<>();
 	}
 
 	public void addSingleMatch(SingleMatch match) {
-		singleMatches.add(match);
+		matches.add(match);
 	}
 
 	public void addTagMatch(TagMatch match) {
-		tagMatches.add(match);
+		matches.add(match);
 	}
 
 	public int points(Wrestler wrestler) {
@@ -25,11 +23,7 @@ public class Company {
 
 		int id = wrestler.getId();
 
-		for (SingleMatch match : singleMatches) {
-			points += match.calculatePoints(id);
-		}
-
-		for (TagMatch match : tagMatches) {
+		for (Match match : matches) {
 			points += match.calculatePoints(id);
 		}
 

--- a/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/Match.java
+++ b/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/Match.java
@@ -1,0 +1,5 @@
+package br.edu.insper.desagil.aps5.wrestling;
+
+public abstract class Match {
+	public abstract int calculatePoints(int id);
+}

--- a/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/SingleMatch.java
+++ b/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/SingleMatch.java
@@ -16,4 +16,11 @@ public class SingleMatch {
 	public int getIdLoser() {
 		return idLoser;
 	}
+
+	public int calculatePoints(int id) {
+		if (idWinner == id) {
+			return 2;
+		}
+		return 0;
+	}
 }

--- a/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/SingleMatch.java
+++ b/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/SingleMatch.java
@@ -1,6 +1,6 @@
 package br.edu.insper.desagil.aps5.wrestling;
 
-public class SingleMatch {
+public class SingleMatch extends Match {
 	private int idWinner;
 	private int idLoser;
 
@@ -17,6 +17,7 @@ public class SingleMatch {
 		return idLoser;
 	}
 
+	@Override
 	public int calculatePoints(int id) {
 		if (idWinner == id) {
 			return 2;

--- a/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/TagMatch.java
+++ b/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/TagMatch.java
@@ -28,4 +28,11 @@ public class TagMatch {
 	public int getIdLoserTeamSecondMember() {
 		return idLoserTeamSecondMember;
 	}
+
+	public int calculatePoints(int id) {
+		if (idWinnerTeamFirstMember == id || idLoserTeamSecondMember == id) {
+			return 1;
+		}
+		return 0;
+	}
 }

--- a/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/TagMatch.java
+++ b/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/TagMatch.java
@@ -1,6 +1,6 @@
 package br.edu.insper.desagil.aps5.wrestling;
 
-public class TagMatch {
+public class TagMatch extends Match {
 	private int idWinnerTeamFirstMember;
 	private int idWinnerTeamSecondMember;
 	private int idLoserTeamFirstMember;
@@ -29,6 +29,7 @@ public class TagMatch {
 		return idLoserTeamSecondMember;
 	}
 
+	@Override
 	public int calculatePoints(int id) {
 		if (idWinnerTeamFirstMember == id || idLoserTeamSecondMember == id) {
 			return 1;

--- a/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/TagMatch.java
+++ b/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/TagMatch.java
@@ -1,37 +1,33 @@
 package br.edu.insper.desagil.aps5.wrestling;
 
 public class TagMatch extends Match {
-	private int idWinnerTeamFirstMember;
-	private int idWinnerTeamSecondMember;
-	private int idLoserTeamFirstMember;
-	private int idLoserTeamSecondMember;
+	private Team winnerTeam;
+	private Team loserTeam;
 
 	public TagMatch(int idWinnerTeamFirstMember, int idWinnerTeamSecondMember, int idLoserTeamFirstMember, int idLoserTeamSecondMember) {
-		this.idWinnerTeamFirstMember = idWinnerTeamFirstMember;
-		this.idWinnerTeamSecondMember = idWinnerTeamSecondMember;
-		this.idLoserTeamFirstMember = idLoserTeamFirstMember;
-		this.idLoserTeamSecondMember = idLoserTeamSecondMember;
+		this.winnerTeam = new Team(idWinnerTeamFirstMember, idWinnerTeamSecondMember);
+		this.loserTeam = new Team(idLoserTeamFirstMember, idLoserTeamSecondMember);
 	}
 
 	public int getIdWinnerTeamFirstMember() {
-		return idWinnerTeamFirstMember;
+		return winnerTeam.getIdFirst();
 	}
 
 	public int getIdWinnerTeamSecondMember() {
-		return idWinnerTeamSecondMember;
+		return winnerTeam.getIdSecond();
 	}
 
 	public int getIdLoserTeamFirstMember() {
-		return idLoserTeamFirstMember;
+		return loserTeam.getIdFirst();
 	}
 
 	public int getIdLoserTeamSecondMember() {
-		return idLoserTeamSecondMember;
+		return loserTeam.getIdSecond();
 	}
 
 	@Override
 	public int calculatePoints(int id) {
-		if (idWinnerTeamFirstMember == id || idLoserTeamSecondMember == id) {
+		if (winnerTeam.getIdFirst() == id || loserTeam.getIdSecond() == id) {
 			return 1;
 		}
 		return 0;

--- a/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/Team.java
+++ b/wrestling/src/main/java/br/edu/insper/desagil/aps5/wrestling/Team.java
@@ -1,0 +1,19 @@
+package br.edu.insper.desagil.aps5.wrestling;
+
+public class Team {
+	private int idFirst;
+	private int idSecond;
+
+	public Team(int idFirst, int idSecond) {
+		this.idFirst = idFirst;
+		this.idSecond = idSecond;
+	}
+
+	public int getIdFirst() {
+		return idFirst;
+	}
+
+	public int getIdSecond() {
+		return idSecond;
+	}
+}


### PR DESCRIPTION
Neste pull request são feitas duas refatorações. Apenas uma das duas seria suficiente.

**Primeira refatoração**

Os cálculos de pontuação para SingleMatch e TagMatch são diferentes. O código original implementa essa diferença mantendo duas listas separadas em Company. Ao varrer a primeira lista usa-se um cálculo e ao varrer a segunda usa-se outro. Isso significa que Company é responsável por diferenciar os tipos de Matches e calcular a pontuação de acordo. A refatoração proposta busca melhorar a coesão do código, movendo a responsabilidade de fazer o cálculo para as classes SingleMatch e TagMatch. Além disso, ela faz essas duas classes estenderem uma nova classe Match. Dessa forma, a responsabilidade de diferenciar os tipos de match é movida para o mecanismo de sobrecarga.

Essa refatoração também pode ser interpretada como uma abstração, pois os detalhes de implementação do cálculo de pontuação são abstraídos para um método calculatePoints. A classe Company precisa apenas usar esse cálculo, sem precisar saber os detalhes.

**Segunda refatoração**

A classe TagMatch possui atributos que representam detalhes internos do time vencedor e outros atributos que representam detalhes internos do time perdedor. A refatoração proposta cria uma nova classe Team, que permite abstrair esses detalhes para objetos que representam times. Dessa forma, os detalhes ficam encapsulados nesses objetos e são expostos apenas sob demanda.

Essa refatoração também pode ser interpretada como uma melhoria de coesão, pois TagMatch originalmente tinha a responsabilidade de representar os dois times, usando apenas os nomes dos atributos para separar os dados. Movendo essa responsabilidade para os objetos do tipo Team, deixamos TagMatch apenas com a responsabilidade de diferenciar times, e não cada uma de suas informações internas.

Essa refatoração também pode ser interpretada como uma melhoria de coesão, pois a versão original de TagMatch é responsável por representar os times em si.

**Observações**

- Alguns nomes de atributo poderiam ser melhorados, mas evitamos fazer isso porque isso implicaria em mudar seus getters e setters também. E isso poderia quebrar algum código que os esteja usando.

- A condição do cálculo da pontuação em TagMatch parece incorreta (faz mais sentido ser idWinnerTeamSecondMember em vez de idLoserTeamSecondMember). No entanto, vamos manter esse aparente erro, pois uma refatoração não deve mudar funcionalidade. Nem mesmo para consertar bugs.